### PR TITLE
Fix typo causing failure in login

### DIFF
--- a/src/PtpUploader/Ptp.py
+++ b/src/PtpUploader/Ptp.py
@@ -90,7 +90,7 @@ def __LoginInternal():
                 % jsonLoad
             )
         else:
-            Settings.AntiCsrfToken = jsonLoad["Settings.AntiCsrfToken"]
+            Settings.AntiCsrfToken = jsonLoad["AntiCsrfToken"]
         MyGlobals.SaveCookies()
 
 


### PR DESCRIPTION
This typo causes failure to login while running `Ptpuploader runuploader`

This typo was introduced while making the 2fa changes 16 days ago.
I reckon this wasn't noticed because you already have cookies saved locally. So you should be able to replicate the login failure if you delete your cookie pickle file