### PR TITLE
Add missing import PtpUploaderMessageStopJob

### DIFF
--- a/src/PtpUploader/web/views.py
+++ b/src/PtpUploader/web/views.py
@@ -27,6 +27,7 @@ from PtpUploader import nfo_parser
 from PtpUploader.PtpUploaderMessage import (
     PtpUploaderMessageStartJob,
     PtpUploaderMessageDeleteJob,
+    PtpUploaderMessageStopJob
 )
 from PtpUploader.ReleaseInfo import ReleaseInfo
 from PtpUploader.Settings import Settings, config


### PR DESCRIPTION
Trying to stop a job throws 500:
2022-06-05 18:19:54,717 ERROR django.request Internal Server Error: /job/240/stop
Traceback (most recent call last):
  File "..\<path>../django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File ""..\<path>../django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File ""..\<path>../django/contrib/auth/decorators.py", line 21, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File ""..\<path>../PtpUploader/web/views.py", line 344, in stop_job
    MyGlobals.PtpUploader.add_message(PtpUploaderMessageStopJob(r_id))
NameError: name 'PtpUploaderMessageStopJob' is not defined


This bug was introduced when the linting changes were committed 5 days ago:
https://github.com/kannibalox/PtpUploader/commit/6ad3990a282471de454eb79200ad9a7eaf3533e3